### PR TITLE
fix: amending logic for start date selection for ESPP price calculation

### DIFF
--- a/src/main/java/com/kelvinconnect/discord/command/StockCommand.java
+++ b/src/main/java/com/kelvinconnect/discord/command/StockCommand.java
@@ -110,16 +110,11 @@ public class StockCommand implements CommandExecutor {
 
     private double getEsppPrice(Stock stock) throws IOException {
         ZonedDateTime currentDate = ZonedDateTime.now().truncatedTo(ChronoUnit.DAYS);
-        boolean isLeapYear = currentDate.toLocalDate().isLeapYear();
-
-        // 2021-04-01 = 91st day of year
-        ZonedDateTime summerStartDate = currentDate.withDayOfYear(isLeapYear ? 92 : 91);
-        // 2021-10-01 = 274th day of year
-        ZonedDateTime winterStartDate = currentDate.withDayOfYear(isLeapYear ? 275 : 274);
+        ZonedDateTime summerStartDate = currentDate.withMonth(4).withDayOfMonth(1);
+        ZonedDateTime winterStartDate = currentDate.withMonth(10).withDayOfMonth(1);
         boolean isSummer = (currentDate.isAfter(summerStartDate) && currentDate.isBefore(winterStartDate));
 
-        ZonedDateTime firstDayOfYear = currentDate.withDayOfYear(1);
-        if (!isSummer && (currentDate.isBefore(summerStartDate) && currentDate.isAfter(firstDayOfYear))) {
+        if (!isSummer && (currentDate.isBefore(summerStartDate))) {
             // Between January 1st and April 1st, we're interested in last year's October
             winterStartDate = winterStartDate.minusYears(1);
         }
@@ -133,19 +128,18 @@ public class StockCommand implements CommandExecutor {
             startPrice = startDatePrices.get(startDate);
         } else {
             Calendar endDate = (Calendar) startDate.clone();
-            // we only really need one day's worth of history
-            endDate.add(Calendar.DAY_OF_YEAR, 1);
+            // Three days of history to cover weekends
+            endDate.add(Calendar.DAY_OF_YEAR, 3);
 
-            // fetch stock history only if we don't have this start date already
+            // Fetch stock history only if we don't have this start date already
             List<HistoricalQuote> stockHistory = stock.getHistory(startDate, endDate, Interval.DAILY);
 
-            // Okay, so when we get this historical data, we actually don't necessarily know if the date we selected
-            // has any data, and if it doesn't, we can end up a weekend off.
-            // So here, we prefer to select a quote from the exact date, and if that doesn't exist, we just take
-            // the first one in the collection
+            // If the designated date is on a weekend,we need the first closing price *after* that date
             Optional<HistoricalQuote> startDateQuote = stockHistory.stream()
-                    .filter(q -> q.getDate().toInstant().equals(startDate.toInstant())).findFirst();
+                    .filter(q -> q.getDate().toInstant().isAfter(startDate.toInstant())).findFirst();
 
+            // I don't think this should happen, but if we can't get the price for a day after the designated date,
+            // we just get the price on the first day returned from the history.
             startPrice = startDateQuote.map(HistoricalQuote::getClose).orElseGet(() -> stockHistory.get(0).getClose());
 
             startDatePrices.put(startDate, startPrice);


### PR DESCRIPTION
Simplifying some of the code, and crucially extending our history period to cover weekends, and choosing the first date *after* the designated start date to match the logic in reality. 